### PR TITLE
Use wget instead of git to download beef

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,25 +5,23 @@ ARG COMMIT=8876f69ba618c5872b3fb1bbe543892ad05de54e
 
 ENV LANG="C.UTF-8" \
     DEPS="build-essential \
-          git \
           libsqlite3-dev \
-          libcurl4-openssl-dev"
+          libcurl4-openssl-dev \
+          wget"
 
 RUN apt-get update \
   && apt-get install -y $DEPS \
                         sqlite3 \
                         nodejs \
   && useradd -m beef \
-  && git clone --depth=1 \
-    --branch=master \
-    https://github.com/beefproject/beef.git \
-    /home/beef/beef \
+  && wget -q https://github.com/beefproject/beef/tarball/$COMMIT -O beef.tgz \
+  && mkdir /home/beef/beef \
+  && tar -xzf beef.tgz --strip 1 -C /home/beef/beef \
   && cd /home/beef/beef \
-  && git checkout $COMMIT \
   && chown -R beef:beef /home/beef \
   && bundle install --without test development \
   \
-  && rm -rf /home/beef/beef/.git \
+  && rm -rf beef.tgz \
   && apt-get purge -y $DEPS \
   && apt-get -y autoremove \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Using git --depth=1 is good to optimize the download, but it only get the latest commit so it fails when later it tries to "git checkout" to a specific commit (which isn't the latest one now)

I tested this PR :)