### PR TITLE
Do not change password when restarting if already customized

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,15 +6,26 @@ DEFAULT_BEEF_USER="beef"
 CHOSEN_BEEF_PASSWORD=$RANDOM_BEEF_PASSWORD
 CHOSEN_BEEF_USER=$DEFAULT_BEEF_USER
 
+CURRENT_PWD=$(grep -oEi 'passwd\: \"(.*?)\"' config.yaml | cut -d'"' -f2)
+
 if [ $BEEF_PASSWORD ]; then
-    sed -i "s/passwd: \"beef\"/passwd: \"$BEEF_PASSWORD\"/" config.yaml
+    # explicit password was given, use it instead of random
     CHOSEN_BEEF_PASSWORD=$BEEF_PASSWORD
 else
-    sed -i "s/passwd: \"beef\"/passwd: \"$RANDOM_BEEF_PASSWORD\"/" config.yaml
+    if [ "$CURRENT_PWD" = "beef" ]; then
+        # config still contains the default password so change it for a random one
+        CHOSEN_BEEF_PASSWORD=$RANDOM_BEEF_PASSWORD
+    else
+        # config was already changed with a random password, so don't change it!
+        CHOSEN_BEEF_PASSWORD=$CURRENT_PWD
+    fi;
 fi
+# replace anything already set, by chosen or random password
+sed -i "s/passwd: .*/passwd: \"$CHOSEN_BEEF_PASSWORD\"/" config.yaml
 
 if [ $BEEF_USER ]; then
-    sed -i "s/user:   \"beef\"/user: \"$BEEF_USER\"/" config.yaml
+    # explicit user was given, replace anything currently set
+    sed -i "s/user: .*/user: \"$BEEF_USER\"/" config.yaml
     CHOSEN_BEEF_USER=$BEEF_USER
 fi
 


### PR DESCRIPTION
Closes #5

Here is an example.
First, without specifying desired user and password:
```console
# docker run -it --name beef -p3000:3000  beef
Beef credentials: beef:iXlZiIU3pSHKFPzCIj33PlxYvaGeDNhy
[...]

# check that credentials are correctly set:
# docker exec -it beef bash -c "grep user config.yaml ; grep passwd config.yaml"
        user:   "beef"
        passwd: "iXlZiIU3pSHKFPzCIj33PlxYvaGeDNhy"
# docker stop beef
# re-start container, see that password stays the same:
# docker start -i beef
Beef credentials: beef:iXlZiIU3pSHKFPzCIj33PlxYvaGeDNhy
# and check that credentials did not change in file:
# docker exec -it beef bash -c "grep user config.yaml ; grep passwd config.yaml"
        user:   "beef"
        passwd: "iXlZiIU3pSHKFPzCIj33PlxYvaGeDNhy"

# delete container and re-create one:
# docker run -it --name beef -p3000:3000  beef
Beef credentials: beef:S0U0mp2nsMILJE4hMzCZdueGCEN8nPLw
[...]

# check that credentials are correctly set:
# docker exec -it beef bash -c "grep user config.yaml ; grep passwd config.yaml"
        user:   "beef"
        passwd: "S0U0mp2nsMILJE4hMzCZdueGCEN8nPLw"
```

And now, if we specify user and password:
```console
# docker run -it --name beef -p3000:3000 -e BEEF_USER=myuser -e BEEF_PASSWORD=mypassword beef
Beef credentials: myuser:mypassword
[...]

# check that credentials are correctly set:
# docker exec -it beef bash -c "grep user config.yaml ; grep passwd config.yaml"
        user: "myuser"
        passwd: "mypassword"

# re-start container
# docker stop beef
# docker start -i beef
Beef credentials: myuser:mypassword
[...]

# check that credentials are correctly set:
# docker exec -it beef bash -c "grep user config.yaml ; grep passwd config.yaml"
        user: "myuser"
        passwd: "mypassword"
```